### PR TITLE
Issue/13 pairing status should have pending field

### DIFF
--- a/src/main/java/com/toopher/PairingStatus.java
+++ b/src/main/java/com/toopher/PairingStatus.java
@@ -47,7 +47,7 @@ public class PairingStatus extends ApiResponseObject {
         JSONObject user = json.getJSONObject("user");
         this.userId = user.getString("id");
         this.userName = user.getString("name");
-        this.enabled = json.getBoolean("pending");
+        this.pending = json.getBoolean("pending");
         this.enabled = json.getBoolean("enabled");
     }
 }

--- a/src/test/java/com/toopher/TestToopherAPI.java
+++ b/src/test/java/com/toopher/TestToopherAPI.java
@@ -18,6 +18,11 @@ public class TestToopherAPI {
 
         assertEquals(httpClient.getLastCalledMethod(), "POST");
         assertEquals(httpClient.getLastCalledData("pairing_phrase"), "awkward turtle");
+        
+        assertEquals(pairing.userId, "1");
+        assertEquals(pairing.userName, "some user");
+        assertTrue(pairing.pending);
+        assertTrue(pairing.enabled);
     }
 
     private URI createURI(String url) {


### PR DESCRIPTION
This PR addresses Issue #13. It adds a pending field to the `PairingStatus` object so users can use the same `while (pairing.pending)` logic they would for authentications.
