### PR TITLE
Make resetEmail optional for iframe

### DIFF
--- a/src/main/java/com/toopher/ToopherIframe.java
+++ b/src/main/java/com/toopher/ToopherIframe.java
@@ -114,7 +114,7 @@ public final class ToopherIframe {
      * @param userName
      *          Unique name that identifies this user.  This will be displayed to the user on
      *          their mobile device when they pair or authenticate
-     * @param resetEmail
+     * @param resetEmail (optional)
      *          Email address that the user has access to.  In case the user has lost or cannot
      *          access their mobile device, Toopher will send a reset email to this address
      * @param ttl
@@ -127,7 +127,9 @@ public final class ToopherIframe {
         final List<NameValuePair> params = new ArrayList<NameValuePair>(4);
         params.add(new BasicNameValuePair("v", IFRAME_VERSION));
         params.add(new BasicNameValuePair("username", userName));
-        params.add(new BasicNameValuePair("reset_email", resetEmail));
+        if (resetEmail != null) {
+            params.add(new BasicNameValuePair("reset_email", resetEmail));
+        }
         params.add(new BasicNameValuePair("expires", String.valueOf((getDate().getTime() / 1000) + ttl)));
         return getOAuthUri(baseUri + "web/pair", params, consumerKey, consumerSecret);
     }

--- a/src/test/java/com/toopher/TestToopherIframe.java
+++ b/src/test/java/com/toopher/TestToopherIframe.java
@@ -42,6 +42,14 @@ public class TestToopherIframe {
     }
 
     @Test
+    public void testGetPairUriWithoutResetEmail() {
+        ToopherIframe.setDateOverride(TEST_DATE);
+        ToopherIframe.setNonceOverride(OAUTH_NONCE);
+        Map<String, String> params = nvp2map(URLEncodedUtils.parse(iframeApi.pairUri("jdoe", null, REQUEST_TTL), Charset.forName("UTF-8")));
+        assertEquals("s/jY/wPfXafzpf9xBUkIkdYaXII=", params.get("oauth_signature"));
+    }
+
+    @Test
     public void testGetAuthUri() {
         ToopherIframe.setDateOverride(TEST_DATE);
         ToopherIframe.setNonceOverride(OAUTH_NONCE);


### PR DESCRIPTION
This PR makes the library more flexible (or at least more explicit) when there is no `resetEmail`. Addresses issue #17: when writing a couple implementations on the iframe, we found we will not always have a `resetEmail`. 
