### PR TITLE
Add Coveralls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build
 Status](https://travis-ci.org/toopher/toopher-java.png?branch=master)](https://travis-ci.org/toopher/toopher-java)
-[![Coverage Status](https://img.shields.io/coveralls/toopher/toopher-java.svg)](https://coveralls.io/r/toopher/toopher-java?branch=feature%2Fcoveralls)
 
 #### Introduction
 ToopherJava is a Toopher API library that simplifies the task of interfacing with the Toopher API from Java code.  This project includes all the dependency libraries and handles the required OAuth and JSON functionality so you can focus on just using the API.

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,38 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.1.201405082137 </version>
+                <configuration>
+                    <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
+                    <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
+                    <excludes>
+                        <exclude>**/ToopherAPIDemo.java</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>travis</id>
@@ -93,7 +125,7 @@
                         <version>0.7.1.201405082137 </version>
                         <configuration>
                             <excludes>
-                                <exclude>**/*Demo.java</exclude>
+                                <exclude>**/ToopherAPIDemo.java</exclude>
                             </excludes>
                         </configuration>
                         <executions>


### PR DESCRIPTION
This PR will enable [Coveralls](https://coveralls.io/r/toopher/toopher-java) with [JaCoCo](http://www.eclemma.org/jacoco/) for code coverage. This is a work in progress as I figure out how to enable Coveralls for Java projects.

Edit: Figured it out. Looking to merge soon.
